### PR TITLE
Publish the contracts in the npm registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ AZTEC is maintained as a monorepo with multiple sub packages. Please find a comp
 | ------- | ------- | ----------- |
 | [`aztec.js`](/packages/aztec.js) | [![npm](https://img.shields.io/npm/v/aztec.js.svg)](https://www.npmjs.com/package/aztec.js) | An aggregate package combining many smaller utility packages for interacting with the AZTEC Protocol |
 | [`@aztec/contract-artifacts`](/packages/contract-artifacts) | [![npm](https://img.shields.io/npm/v/@aztec/contract-artifacts.svg)](https://www.npmjs.com/package/@aztec/contract-artifacts) | AZTEC smart contract compiled artifacts |
-| [`@aztec/contract-addresses`](/packages/contract-addresses) | [![npm](https://img.shields.io/npm/v/@aztec/contract-addresses.svg)](https://www.npmjs.com/package/@aztec/contract-addresses) | A tiny utility library for getting known deployed contract addresses for a particular network | [`@aztec/dev-utils`](/packages/dev-utils) | [![npm](https://img.shields.io/npm/v/@aztec/dev-utils.svg)](https://www.npmjs.com/package/@aztec/dev-utils) | Dev utils to be shared across AZTEC projects and packages. |
+| [`@aztec/contract-addresses`](/packages/contract-addresses) | [![npm](https://img.shields.io/npm/v/@aztec/contract-addresses.svg)](https://www.npmjs.com/package/@aztec/contract-addresses) | A tiny utility library for getting known deployed contract addresses for a particular network |
+| [`@aztec/dev-utils`](/packages/dev-utils) | [![npm](https://img.shields.io/npm/v/@aztec/dev-utils.svg)](https://www.npmjs.com/package/@aztec/dev-utils) | Dev utils to be shared across AZTEC projects and packages |
 
 ### Solidity Packages
 

--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ $ npm install @aztec/dev-utils
 To see a demo, head to the protocol package:
 
 ```bash
-* cd packages/protocol
+$ cd packages/protocol
 ```
 
 Make sure you use your own private keys instead of the defaults in `demo/accounts.json`. Then:
 
 ```bash
-* npm install
-* truffle migrate --network rinkeby
-* npm run demo:rinkeby
+$ npm install
+$ truffle migrate --network rinkeby
+$ npm run demo:rinkeby
 ```
 
 For more information, check out our [documentation](https://aztecprotocol.github.io/AZTEC/).

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ AZTEC is maintained as a monorepo with multiple sub packages. Please find a comp
 
 ### Solidity Packages
 
-| Package                                            | Description                                                                      |
-| -------------------------------------------------- | -------------------------------------------------------------------------------- |
-| [`@aztec/protocol`](/packages/protocol)            | AZTEC solidity smart contracts & tests                                           |
+| Package | Version | Description |
+| ------- | ------- | ----------- |
+| [`@aztec/protocol`](/packages/protocol) | [![npm](https://img.shields.io/npm/v/@aztec/protocol.svg)](https://www.npmjs.com/package/@aztec/protocol) | AZTEC solidity smart contracts & tests |
 
 ### Private Packages
 

--- a/packages/huff/README.md
+++ b/packages/huff/README.md
@@ -1,4 +1,4 @@
-## **Huff**: a programming language for the Ethereum Virtual Machine  
+## **Huff**: a programming language for the Ethereum Virtual Machine
 
 <p align="center"><img src="https://i.imgur.com/SVRjUhU.png" width="640px"/></p>
 
@@ -8,13 +8,13 @@ Huff enables the construction of EVM assembly macros - blocks of bytecode that c
 
 Huff doesn't hide the workings of the EVM behind syntactic sugar. In fact, Huff doesn't hide anything at all. Huff does not have variables, instead directly exposing the EVM's program stack to the developer to be directly manipulated.  
 
-### **"Wait...that sounds terrible! What is the point of huff?"**  
+### **"Wait...that sounds terrible! What is the point of huff?"**
 
 I developed Huff while writing [weierstrudel](https://github.com/AztecProtocol/weierstrudel/tree/master/huff_modules), an elliptic curve arithmetic library. Huff is designed for developing highly optimized algorithms where direct manipulation of the program's bytecode is preferred.  
 
-Huff supports a form of templating - Huff macros can accept template parameters, which in turn are Huff macros. This allows for customizable macros that are ideal for loop unrolling.  
+Huff supports a form of templating - Huff macros can accept template parameters, which in turn are Huff macros. This allows for customizable macros that are ideal for loop unrolling. 
 
-Huff algorithms can be broken down into their constituent macros and rigorously ested without having to split the algorithm into functions and invoke jump instructions.
+Huff algorithms can be broken down into their constituent macros and rigorously tested without having to split the algorithm into functions and invoke jump instructions.
 
 ### **Huff syntax**
 
@@ -154,7 +154,7 @@ Please, by all means. Huff is open-source and licensed under LGPL-3.0.
 
 ### **Usage**
 
-```
+```js
 const { Runtime } = require('huff');
 
 const main = new Runtime('main_loop.huff', 'path_to_macros');

--- a/packages/protocol/.npmignore
+++ b/packages/protocol/.npmignore
@@ -1,0 +1,1 @@
+Migrations.sol

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -4,6 +4,9 @@
   "author": "AZTEC",
   "description": "AZTEC smart contract repository",
   "license": "LGPL-3.0",
+  "files": [
+    "/contracts"
+  ],
   "homepage": "https://github.com/AztecProtocol/AZTEC#readme",
   "keywords": [
     "aztec",

--- a/packages/weierstrudel/README.md
+++ b/packages/weierstrudel/README.md
@@ -13,7 +13,7 @@ weierstrudel is written entirely in [Huff](https://github.com/AztecProtocol/huff
 * Using the GLV technique to exploit a curve endomorphism and reduce the number of 'point doubling' operations in half.  
 * Using Shamir's trick to combine multiple scalar multiplications into a single algorithm, fixing the number of 'point doubling' operations to ~127  
 * Using Windowed-Non-Adjacent-Form representations for scalar multipliers, reducing the number of 'point addition' operations to ~50 per point  
-* Using the difference between the bn254 curve's 254-bit field modulus and the EVM's 256 word size to defer modular reductions until absolutely neccessary  
+* Using the difference between the bn254 curve's 254-bit field modulus and the EVM's 256 word size to defer modular reductions until absolutely necessary  
 
 `weierstrudel` makes extensive use of bit-shift opcodes and is only compatible with Ethereum once the Constantinople hard-fork has been activated.  
 
@@ -55,27 +55,27 @@ Of course! `weierstrudel` is open-source software, licensed under LGPL-3.0. Howe
 
 Gas estimates can be obtained by running `npm run benchmark`. For reference, the scalar multiplication precompile costs `40,000` gas per point. This is excluding the overheads of having to make a contract call per point when using the precompiles, as well as calling the point addition precompile to combine points into a single sum.
 
-Number of points | Approximate gas cost (average of 10 runs) | Cost per point
---- | --- | ---
-1 | 47,593 | 47,593
-2 | 69,057 | 34,528
-3 | 89,997 | 29,999
-4 | 111,554 | 27,889
-5 | 133,580 | 26,716
-6 | 154,759 | 25,793
-7 | 176,051 | 25,150
-8 | 196,570 | 24,571
-9 | 219,103 | 24,244
-10 | 239,872 | 23,987
-11 | 261,243 | 23,749
-12 | 282,349 | 23,529
-13 | 304,197 | 23,400
-14 | 324,816 | 23,201
-15 | 348,173 | 23,211
+| Number of points | Approximate gas cost (average of 10 runs) | Cost per point |
+| ---------------- | ----------------------------------------- | -------------- |
+| 1 | 47,593 | 47,593 |
+| 2 | 69,057 | 34,528 |
+| 3 | 89,997 | 29,999 |
+| 4 | 111,554 | 27,889 |
+| 5 | 133,580 | 26,716 |
+| 6 | 154,759 | 25,793 |
+| 7 | 176,051 | 25,150 |
+| 8 | 196,570 | 24,571 |
+| 9 | 219,103 | 24,244 |
+| 10 | 239,872 | 23,987 |
+| 11 | 261,243 | 23,749 |
+| 12 | 282,349 | 23,529 |
+| 13 | 304,197 | 23,400 |
+| 14 | 324,816 | 23,201 |
+| 15 | 348,173 | 23,211 |
 
 ### **Deployed weierstrudel**
 
-`weierstrudel` is currently deployed on [Ropsten](https://ropsten.etherscan.io/address/0xd68131a43ca870ce0a27f5ace6c696dd6c442683#code)
+`weierstrudel` is currently deployed on [Ropsten](https://ropsten.etherscan.io/address/0xd68131a43ca870ce0a27f5ace6c696dd6c442683#code).
 
 ### **Usage**
 


### PR DESCRIPTION
Changelog:

- Publish the protocol contracts in the [npm registry](https://www.npmjs.com/package/@aztec/protocol)
- Small fix for the table in the top-level README
- Replace `*` with `$` in the bash commands of the top-level README
- Small typo fixes in various package READMEs