### PR TITLE
Get rid of unnecessary comments

### DIFF
--- a/packages/aztec.js/src/proof/bilateralSwap/index.js
+++ b/packages/aztec.js/src/proof/bilateralSwap/index.js
@@ -63,17 +63,6 @@ bilateralSwap.computeChallenge = (...challengeVariables) => {
  * @returns {{proofData:Array[string]}, {challenge: string}} - proof data and challenge
  */
 bilateralSwap.constructBilateralSwap = (notes, sender) => {
-    // finalHash is used to create final proof challenge
-
-    // finalHash.appendBN(new BN(sender.slice(2), 16));
-
-    /*
-    notes.forEach((note) => {
-        finalHash.append(note.gamma);
-        finalHash.append(note.sigma);
-    });
-    */
-
     const bkArray = [];
     const blindingFactors = notes.map((note, i) => {
         let bk = bn128.randomGroupScalar();
@@ -96,7 +85,6 @@ bilateralSwap.constructBilateralSwap = (notes, sender) => {
             bk = bkArray[i - 2];
             B = note.gamma.mul(bk).add(bn128.h.mul(ba));
         }
-        // finalHash.append(B);
         bkArray.push(bk);
 
         return {
@@ -107,7 +95,6 @@ bilateralSwap.constructBilateralSwap = (notes, sender) => {
     });
 
     const challenge = bilateralSwap.computeChallenge(sender, notes, blindingFactors);
-    // finalHash.keccak(groupReduction);
 
     const proofData = blindingFactors.map((blindingFactor, i) => {
         let kBar;

--- a/packages/aztec.js/src/proof/dividendComputation/index.js
+++ b/packages/aztec.js/src/proof/dividendComputation/index.js
@@ -76,7 +76,6 @@ dividendComputation.constructProof = (notes, za, zb, sender) => {
     let zaBN;
     let zbBN;
 
-    // finalHash is used to create final proof challenge
     const rollingHash = new Keccak();
 
     if (BN.isBN(za)) {

--- a/packages/aztec.js/src/proof/joinSplit/index.js
+++ b/packages/aztec.js/src/proof/joinSplit/index.js
@@ -167,7 +167,6 @@ joinSplit.constructJoinSplit = (notes, m, sender, kPublic) => {
         rollingHash.append(note.gamma);
         rollingHash.append(note.sigma);
     });
-    // finalHash is used to create final proof challenge
 
     // define 'running' blinding factor for the k-parameter in final note
     let runningBk = new BN(0).toRed(groupReduction);
@@ -251,7 +250,6 @@ joinSplit.constructJoinSplitModified = (notes, m, sender, kPublic, publicOwner) 
         rollingHash.append(note.gamma);
         rollingHash.append(note.sigma);
     });
-    // finalHash is used to create final proof challenge
 
     // define 'running' blinding factor for the k-parameter in final note
     let runningBk = new BN(0).toRed(groupReduction);

--- a/packages/aztec.js/test/abiEncoder/joinSplit.spec.js
+++ b/packages/aztec.js/test/abiEncoder/joinSplit.spec.js
@@ -39,7 +39,7 @@ function fakeSignature() {
     ];
 }
 
-describe('abiEncioder.joinSplit tests', () => {
+describe('abiEncoder.joinSplit tests', () => {
     let accounts = [];
     let notes = [];
     beforeEach(() => {

--- a/packages/aztec.js/test/abiEncoder/outputCoder.spec.js
+++ b/packages/aztec.js/test/abiEncoder/outputCoder.spec.js
@@ -34,7 +34,7 @@ class HexString extends String {
     }
 }
 
-describe('abiEncioder.outputCoder tests', () => {
+describe('abiEncoder.outputCoder tests', () => {
     let accounts = [];
     let notes = [];
     beforeEach(() => {


### PR DESCRIPTION
Removes the superfluous comments in the `aztec.js` package. Also, fixes a small typo, that is, `abiEncioder`.