### PR TITLE
Set CRS and proof on ACE after deployment

### DIFF
--- a/packages/protocol/migrations/2_deploy_ace.js
+++ b/packages/protocol/migrations/2_deploy_ace.js
@@ -1,6 +1,10 @@
 /* global artifacts */
+const { constants: { CRS } } = require('@aztec/dev-utils');
+
 const ACE = artifacts.require('./ACE.sol');
 
 module.exports = (deployer) => {
-    return deployer.deploy(ACE);
+    return deployer.deploy(ACE).then(async (ace) => {
+        await ace.setCommonReferenceString(CRS);
+    });
 };

--- a/packages/protocol/migrations/3_deploy_joinsplit.js
+++ b/packages/protocol/migrations/3_deploy_joinsplit.js
@@ -1,9 +1,15 @@
 /* global artifacts */
+const ACE = artifacts.require('./ACE.sol');
 const JoinSplit = artifacts.require('./JoinSplit.sol');
 const JoinSplitInterface = artifacts.require('./JoinSplitInterface.sol');
 
 JoinSplit.abi = JoinSplitInterface.abi;
 
 module.exports = (deployer) => {
-    return deployer.deploy(JoinSplit, deployer.network_id);
+    return deployer.deploy(JoinSplit, deployer.network_id).then(async ({ address: joinSplitAddress }) => {
+        const proofId = 1;
+        const isBalanced = true;
+        const ace = await ACE.at(ACE.address);
+        await ace.setProof(proofId, joinSplitAddress, isBalanced);
+    });
 };


### PR DESCRIPTION
The migrations scripts aren't performing the following actions:

```
ACE.setCommonReferenceString(crs)
ACE.setProof(proofId, validatorAddress, isBalanced)
```

Making the contracts deployed on Kovan, Rinkeby and Ropsten not functional.