### PR TITLE
Bug confidential token migrations

### DIFF
--- a/packages/protocol/migrations/4_deploy_token.js
+++ b/packages/protocol/migrations/4_deploy_token.js
@@ -19,7 +19,10 @@ module.exports = (deployer, network) => {
         }
         return deployer.deploy(ERC20Mintable).then(({ address: erc20Address }) => {
             const aceAddress = ACE.address;
-            return deployer.deploy(ZKERC20, 'Cocoa', true, true, true, ERC20_SCALING_FACTOR, erc20Address, aceAddress);
+            const canMint = false;
+            const canBurn = false;
+            const canConvert = true;
+            return deployer.deploy(ZKERC20, 'Cocoa', canMint, canBurn, canConvert, ERC20_SCALING_FACTOR, erc20Address, aceAddress);
         });
     });
 };


### PR DESCRIPTION
Hotfixing the issue with deploying confidential tokens: `canMint` and `canBurn` should be set on `false` because we want to make the token linkable to ERC20 contracts.