### PR TITLE
Various enhancements

### DIFF
--- a/packages/aztec.js/package.json
+++ b/packages/aztec.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aztec.js",
-  "version": "0.4.0-beta.11",
+  "version": "0.4.0-beta.13",
   "author": "AZTEC",
   "description": "AZTEC cryptography library",
   "license": "LGPL-3.0",

--- a/packages/aztec.js/src/proof/joinSplit/index.js
+++ b/packages/aztec.js/src/proof/joinSplit/index.js
@@ -313,7 +313,7 @@ joinSplit.constructJoinSplitModified = (notes, m, sender, kPublic, publicOwner) 
  * @param {string[]} inputNoteOwners array with the owners of the input notes
  * @param {string} publicOwner address(0x0) or the holder of a public token being converted
  * @param {string} kPublic public commitment being added to proof
- * @param {string} aztecAddress address of the JoinSplit contract
+ * @param {string} validatorAddress address of the JoinSplit contract
  * @returns {Object} AZTEC proof data and expected output
  */
 joinSplit.encodeJoinSplitTransaction = ({
@@ -323,7 +323,7 @@ joinSplit.encodeJoinSplitTransaction = ({
     inputNoteOwners,
     publicOwner,
     kPublic,
-    aztecAddress,
+    validatorAddress,
 }) => {
     const m = inputNotes.length;
     const {
@@ -337,7 +337,7 @@ joinSplit.encodeJoinSplitTransaction = ({
             proofDataRaw[index],
             challenge,
             senderAddress,
-            aztecAddress,
+            validatorAddress,
             privateKey
         );
     });

--- a/packages/protocol/contracts/ACE/NoteRegistry.sol
+++ b/packages/protocol/contracts/ACE/NoteRegistry.sol
@@ -185,6 +185,7 @@ contract NoteRegistry {
     function updateInputNotes(bytes memory inputNotes) internal {
         for (uint i = 0; i < inputNotes.getLength(); i += 1) {
             (address owner, bytes32 noteHash,) = inputNotes.get(i).extractNote();
+            // `note` will be stored on the blockchain
             Note storage note = registry[noteHash];
             require(note.status == 1, "input note does not exist!");
             require(note.owner == owner, "input note owner does not match!");
@@ -199,6 +200,7 @@ contract NoteRegistry {
     function updateOutputNotes(bytes memory outputNotes) internal {
         for (uint i = 0; i < outputNotes.getLength(); i += 1) {
             (address owner, bytes32 noteHash,) = outputNotes.get(i).extractNote();
+            // `note` will be stored on the blockchain
             Note storage note = registry[noteHash];
             require(note.status == 0, "output note exists!");
             note.status = uint8(1);

--- a/packages/protocol/migrations/4_deploy_token.js
+++ b/packages/protocol/migrations/4_deploy_token.js
@@ -22,7 +22,16 @@ module.exports = (deployer, network) => {
             const canMint = false;
             const canBurn = false;
             const canConvert = true;
-            return deployer.deploy(ZKERC20, 'Cocoa', canMint, canBurn, canConvert, ERC20_SCALING_FACTOR, erc20Address, aceAddress);
+            return deployer.deploy(
+                ZKERC20,
+                'Cocoa',
+                canMint,
+                canBurn,
+                canConvert,
+                ERC20_SCALING_FACTOR,
+                erc20Address,
+                aceAddress
+            );
         });
     });
 };

--- a/packages/protocol/package-lock.json
+++ b/packages/protocol/package-lock.json
@@ -288,9 +288,9 @@
       }
     },
     "aztec.js": {
-      "version": "0.4.0-beta.11",
-      "resolved": "https://registry.npmjs.org/aztec.js/-/aztec.js-0.4.0-beta.11.tgz",
-      "integrity": "sha512-8IU48LlU5s623sdZPw+lw09cXPGbaW2i81YmqPlYApQv57Q/eqXXHrsx4oKC8Bdi/jeAE5cuFsCvPPGRH7ewYQ==",
+      "version": "0.4.0-beta.13",
+      "resolved": "https://registry.npmjs.org/aztec.js/-/aztec.js-0.4.0-beta.13.tgz",
+      "integrity": "sha512-6/9Dskco0l79eEU8e18tr40jkYoZQRkL/m6unQ0PS4byFg2j61D2MwLbZS+pOKEr+23TkGtcq/5Boj4dOTL3sg==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/protocol",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.3",
   "author": "AZTEC",
   "description": "AZTEC smart contract repository",
   "license": "LGPL-3.0",
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@aztec/dev-utils": "^1.2.0",
-    "aztec.js": "^0.4.0-beta.11",
+    "aztec.js": "0.4.0-beta.13",
     "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.3",
     "bn.js": "^4.11.8",

--- a/packages/protocol/test/ACE/NoteRegistry.js
+++ b/packages/protocol/test/ACE/NoteRegistry.js
@@ -37,7 +37,7 @@ function encodeJoinSplitTransaction({
     inputNoteOwners,
     publicOwner,
     kPublic,
-    aztecAddress,
+    validatorAddress,
 }) {
     const m = inputNotes.length;
     const {
@@ -51,7 +51,7 @@ function encodeJoinSplitTransaction({
             proofDataRaw[index],
             challenge,
             senderAddress,
-            aztecAddress,
+            validatorAddress,
             privateKey
         );
     });
@@ -97,8 +97,8 @@ contract('NoteRegistry', (accounts) => {
                 ...aztecAccounts.map(({ publicKey }, i) => note.create(publicKey, i * 10)),
             ];
             await ace.setCommonReferenceString(CRS);
-            const aztec = await JoinSplit.new();
-            await ace.setProof(1, aztec.address, true);
+            const aztecJoinSplit = await JoinSplit.new();
+            await ace.setProof(1, aztecJoinSplit.address, true);
             const publicOwner = accounts[0];
             proofs[0] = encodeJoinSplitTransaction({
                 inputNotes: [],
@@ -107,7 +107,7 @@ contract('NoteRegistry', (accounts) => {
                 inputNoteOwners: [],
                 publicOwner,
                 kPublic: -10,
-                aztecAddress: aztec.address,
+                validatorAddress: aztecJoinSplit.address,
             });
             proofs[1] = encodeJoinSplitTransaction({
                 inputNotes: notes.slice(0, 2),
@@ -116,7 +116,7 @@ contract('NoteRegistry', (accounts) => {
                 inputNoteOwners: aztecAccounts.slice(0, 2),
                 publicOwner: accounts[1],
                 kPublic: -40,
-                aztecAddress: aztec.address,
+                validatorAddress: aztecJoinSplit.address,
             });
             proofs[2] = encodeJoinSplitTransaction({
                 inputNotes: [],
@@ -125,7 +125,7 @@ contract('NoteRegistry', (accounts) => {
                 inputNoteOwners: [],
                 publicOwner: accounts[2],
                 kPublic: -130,
-                aztecAddress: aztec.address,
+                validatorAddress: aztecJoinSplit.address,
             });
             proofs[3] = encodeJoinSplitTransaction({
                 inputNotes: notes.slice(6, 8),
@@ -134,7 +134,7 @@ contract('NoteRegistry', (accounts) => {
                 inputNoteOwners: aztecAccounts.slice(6, 8),
                 publicOwner: accounts[2],
                 kPublic: 40,
-                aztecAddress: aztec.address,
+                validatorAddress: aztecJoinSplit.address,
             });
             proofs[4] = encodeJoinSplitTransaction({
                 inputNotes: [],
@@ -143,7 +143,7 @@ contract('NoteRegistry', (accounts) => {
                 inputNoteOwners: [],
                 publicOwner: accounts[3],
                 kPublic: -30,
-                aztecAddress: aztec.address,
+                validatorAddress: aztecJoinSplit.address,
             });
             proofs[5] = encodeJoinSplitTransaction({
                 inputNotes: [notes[0], notes[3]],
@@ -152,7 +152,7 @@ contract('NoteRegistry', (accounts) => {
                 inputNoteOwners: [aztecAccounts[0], aztecAccounts[3]],
                 publicOwner: accounts[3],
                 kPublic: 0, // perfectly balanced...
-                aztecAddress: aztec.address,
+                validatorAddress: aztecJoinSplit.address,
             });
 
             erc20 = await ERC20Mintable.new();

--- a/packages/protocol/test/ZKERC20/ZKERC20.js
+++ b/packages/protocol/test/ZKERC20/ZKERC20.js
@@ -42,7 +42,6 @@ contract('ZKERC20', (accounts) => {
         const proofs = [];
         const tokensTransferred = new BN(100000);
 
-
         beforeEach(async () => {
             ace = await ACE.new({
                 from: accounts[0],
@@ -111,8 +110,14 @@ contract('ZKERC20', (accounts) => {
                 aztecAddress: aztecJoinSplit.address,
             });
 
-            erc20 = await ERC20Mintable.new();
+            const proofOutputs = proofs.map(({ expectedOutput }) => {
+                return outputCoder.getProofOutput(expectedOutput, 0);
+            });
+            const proofHashes = proofOutputs.map((proofOutput) => {
+                return outputCoder.hashProofOutput(proofOutput);
+            });
 
+            erc20 = await ERC20Mintable.new();
             zkerc20 = await ZKERC20.new(
                 'Cocoa',
                 false,
@@ -135,9 +140,8 @@ contract('ZKERC20', (accounts) => {
                 noteRegistryAddress,
                 scalingFactor.mul(tokensTransferred),
                 { from: account, gas: 4700000 }
-            ))); // approving tokens
-            const proofOutputs = proofs.map(({ expectedOutput }) => outputCoder.getProofOutput(expectedOutput, 0));
-            const proofHashes = proofOutputs.map(proofOutput => outputCoder.hashProofOutput(proofOutput));
+            )));
+            // approving tokens
             await noteRegistry.publicApprove(
                 proofHashes[0],
                 10,
@@ -158,11 +162,6 @@ contract('ZKERC20', (accounts) => {
                 30,
                 { from: accounts[3] }
             );
-            await Promise.all(accounts.map(account => noteRegistry.publicApprove(
-                noteRegistryAddress,
-                scalingFactor.mul(tokensTransferred),
-                { from: account, gas: 4700000 }
-            ))); // approving tokens
         });
 
         it('will can update a note registry with output notes', async () => {

--- a/packages/protocol/test/ZKERC20/ZKERC20.js
+++ b/packages/protocol/test/ZKERC20/ZKERC20.js
@@ -62,7 +62,7 @@ contract('ZKERC20', (accounts) => {
                 inputNoteOwners: [],
                 publicOwner: accounts[0],
                 kPublic: -10,
-                aztecAddress: aztecJoinSplit.address,
+                validatorAddress: aztecJoinSplit.address,
             });
             proofs[1] = proof.joinSplit.encodeJoinSplitTransaction({
                 inputNotes: notes.slice(0, 2),
@@ -71,7 +71,7 @@ contract('ZKERC20', (accounts) => {
                 inputNoteOwners: aztecAccounts.slice(0, 2),
                 publicOwner: accounts[1],
                 kPublic: -40,
-                aztecAddress: aztecJoinSplit.address,
+                validatorAddress: aztecJoinSplit.address,
             });
             proofs[2] = proof.joinSplit.encodeJoinSplitTransaction({
                 inputNotes: [],
@@ -80,7 +80,7 @@ contract('ZKERC20', (accounts) => {
                 inputNoteOwners: [],
                 publicOwner: accounts[2],
                 kPublic: -130,
-                aztecAddress: aztecJoinSplit.address,
+                validatorAddress: aztecJoinSplit.address,
             });
             proofs[3] = proof.joinSplit.encodeJoinSplitTransaction({
                 inputNotes: notes.slice(6, 8),
@@ -89,7 +89,7 @@ contract('ZKERC20', (accounts) => {
                 inputNoteOwners: aztecAccounts.slice(6, 8),
                 publicOwner: accounts[2],
                 kPublic: 40,
-                aztecAddress: aztecJoinSplit.address,
+                validatorAddress: aztecJoinSplit.address,
             });
             proofs[4] = proof.joinSplit.encodeJoinSplitTransaction({
                 inputNotes: [],
@@ -98,7 +98,7 @@ contract('ZKERC20', (accounts) => {
                 inputNoteOwners: [],
                 publicOwner: accounts[3],
                 kPublic: -30,
-                aztecAddress: aztecJoinSplit.address,
+                validatorAddress: aztecJoinSplit.address,
             });
             proofs[5] = proof.joinSplit.encodeJoinSplitTransaction({
                 inputNotes: [notes[0], notes[3]],
@@ -107,7 +107,7 @@ contract('ZKERC20', (accounts) => {
                 inputNoteOwners: [aztecAccounts[0], aztecAccounts[3]],
                 publicOwner: accounts[3],
                 kPublic: 0, // perfectly balanced...
-                aztecAddress: aztecJoinSplit.address,
+                validatorAddress: aztecJoinSplit.address,
             });
 
             const proofOutputs = proofs.map(({ expectedOutput }) => {


### PR DESCRIPTION
Changelog

- Rename `m` to `memPtr` in assembly code, because `m` represents the size of the input note array in AZTEC.
- Nuke unnecessary calls to `publicApprove` in tests for ZKERC20
- Rename `aztecAddress` param of `encodeJoinSplitTransaction` to `validatorAddress`
- Small formatting fixes
