### PR TITLE
Fix proof hash

### DIFF
--- a/packages/aztec.js/package-lock.json
+++ b/packages/aztec.js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aztec.js",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/aztec.js/package-lock.json
+++ b/packages/aztec.js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aztec.js",
-  "version": "0.4.0-beta.16",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/aztec.js/package.json
+++ b/packages/aztec.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aztec.js",
-  "version": "0.4.0-beta.21",
+  "version": "0.4.2",
   "author": "AZTEC",
   "description": "AZTEC cryptography library",
   "license": "LGPL-3.0",

--- a/packages/aztec.js/package.json
+++ b/packages/aztec.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aztec.js",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": "AZTEC",
   "description": "AZTEC cryptography library",
   "license": "LGPL-3.0",

--- a/packages/aztec.js/src/abiEncoder/outputCoder.js
+++ b/packages/aztec.js/src/abiEncoder/outputCoder.js
@@ -97,7 +97,7 @@ outputCoder.getProofOutput = (proofOutputsHex, i) => {
 };
 
 outputCoder.hashProofOutput = (proofOutput) => {
-    return sha3(`0x${proofOutput}`);
+    return sha3(`0x${proofOutput.slice(0x40)}`);
 };
 
 outputCoder.encodeOutputNote = (note) => {

--- a/packages/aztec.js/src/index.js
+++ b/packages/aztec.js/src/index.js
@@ -1,13 +1,11 @@
-const path = require('path');
-
-const abiEncoder = require(path.join(__dirname, 'abiEncoder'));
-const bn128 = require(path.join(__dirname, 'bn128'));
-const keccak = require(path.join(__dirname, 'keccak'));
-const note = require(path.join(__dirname, 'note'));
-const proof = require(path.join(__dirname, 'proof'));
-const secp256k1 = require(path.join(__dirname, 'secp256k1'));
-const setup = require(path.join(__dirname, 'setup'));
-const sign = require(path.join(__dirname, 'sign'));
+const abiEncoder = require('./abiEncoder');
+const bn128 = require('./bn128');
+const keccak = require('./keccak');
+const note = require('./note');
+const proof = require('./proof');
+const secp256k1 = require('./secp256k1');
+const setup = require('./setup');
+const sign = require('./sign');
 
 module.exports = {
     abiEncoder,

--- a/packages/dev-utils/package-lock.json
+++ b/packages/dev-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/dev-utils",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/dev-utils",
-  "version": "1.3.0-beta.2",
+  "version": "1.3.3",
   "author": "AZTEC",
   "description": "Dev utils to be shared across AZTEC packages",
   "license": "LGPL-3.0",

--- a/packages/dev-utils/src/index.js
+++ b/packages/dev-utils/src/index.js
@@ -1,8 +1,9 @@
 const constants = require('./constants');
+const errors = require('./errors');
 const exceptions = require('./exceptions');
 
 module.exports = {
     constants,
-    exceptions,
     errors,
+    exceptions,
 };

--- a/packages/dev-utils/src/index.js
+++ b/packages/dev-utils/src/index.js
@@ -1,8 +1,5 @@
-const path = require('path');
-
-const constants = require(path.join(__dirname, 'constants'));
-const exceptions = require(path.join(__dirname, 'exceptions'));
-const errors = require(path.join(__dirname, 'errors'));
+const constants = require('./constants');
+const exceptions = require('./exceptions');
 
 module.exports = {
     constants,

--- a/packages/protocol/package-lock.json
+++ b/packages/protocol/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aztec/protocol",
-  "version": "0.4.0-beta.5",
+  "version": "0.4.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
<!-- Please write an overview description of the problem -->
## Problem

The length of the proof output was mistakenly being mixed in hashing the proof.

<!-- Please write an overview description of the solution -->
## Solution

Modify `outputCoder.hashProofOutput` to get rid of the first 32 bytes:

```javascript
return sha3(`0x${proofOutput.slice(0x40)}`);
```

<!-- What packages did you update? How were they changed? -->
## Packages Updated

- aztec.js

<!-- Make sure that all of the points below are checked -->
## Checklist

- [x] Prefix PR title with [WIP] if necessary.
- [x] Write tests for added code when needed.
- [x] Update documentation when needed.
